### PR TITLE
Add cors header to request responses

### DIFF
--- a/core/src/main/java/org/mitpu/referral/core/CoreApplication.java
+++ b/core/src/main/java/org/mitpu/referral/core/CoreApplication.java
@@ -2,6 +2,9 @@ package org.mitpu.referral.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 public class CoreApplication {
@@ -10,4 +13,13 @@ public class CoreApplication {
 		SpringApplication.run(CoreApplication.class, args);
 	}
 
+	@Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**").allowedOrigins("*");
+            }
+        };
+    }
 }


### PR DESCRIPTION
Front end was complaining about `Access-Control-Allow-Origin` missing! This enables CORS for all origins!
# Testing
1. Load frontend in https://github.com/MITPU/referral/pull/35/files and see
<img width="1760" alt="Screen Shot 2020-08-05 at 9 32 04 PM" src="https://user-images.githubusercontent.com/1626382/89491282-c7150880-d763-11ea-93bd-93e16b5fddd2.png">
